### PR TITLE
Remove "main" : "scripts/w3c-schemas.js"

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -5,7 +5,6 @@
 		"Alexey Valikov"
 	],
 	"description": "Jsonix mappings for W3C Schemas.",
-	"main": "scripts/w3c-schemas.js",
 	"keywords" : [
 		"json",
 		"xml",


### PR DESCRIPTION
Remove main:scripts/w3c-schemas.js to prevent bower and wiredep to auto include this file. This file is to load modules in nodejs context but in a browser context fails, because `module` does not exists.

Could we have a new tag with this change? 

Thanks in advance
JM